### PR TITLE
Added -r parameter to choose alternate regions. 

### DIFF
--- a/ec2-check-reserved-instances.py
+++ b/ec2-check-reserved-instances.py
@@ -113,7 +113,7 @@ if unreserved_instances == {}:
 else:
 	ids=""
 	for unreserved_instance in unreserved_instances:
-		if args.names is not None:
+		if args.names:
 			ids = ', '.join(sorted(instance_ids[unreserved_instance]))
 		print "Instance not reserved:\t(%s)\t%s\t%s\t%s" % ( unreserved_instances[ unreserved_instance ], unreserved_instance[0], unreserved_instance[1], ids )
 


### PR DESCRIPTION
Great little utility you have here!  We just started looking into reserved instances in our AWS usage, and since we have a bunch of instances in regions other than us-east-1 I went ahead and modified this to support an optional -r parameter to let you specify a region.  I also fixed a bug in the qty_ calculations since it would throw an exception if either of the instance lists was empty.
