### PR TITLE
VPC support

### DIFF
--- a/ec2-check-reserved-instances.py
+++ b/ec2-check-reserved-instances.py
@@ -31,12 +31,9 @@ for reservation in reservations:
 		elif instance.spot_instance_request_id:
 			sys.stderr.write("Disqualifying instance %s: spot\n" % ( instance.id ) )
 		else:
-			if instance.vpc_id:
-				print "Does not support vpc yet, please be careful when trusting these results"
-			else:
-				az = instance.placement
-				instance_type = instance.instance_type
-				running_instances[ (instance_type, az ) ] = running_instances.get( (instance_type, az ) , 0 ) + 1
+			az = instance.placement
+			instance_type = instance.instance_type
+			running_instances[ (instance_type, az ) ] = running_instances.get( (instance_type, az ) , 0 ) + 1
 
 
 # pprint( running_instances )


### PR DESCRIPTION
VPC is actually supported. I juse removed the if
EC2 FAQ http://aws.amazon.com/ec2/faqs/ states the following:

Q: What happens when I modify the Availability Zone or network Platform
of a Reserved Instance?

If you modify the Availability Zone of a Reserved Instance, its capacity
reservation and pricing benefit stop applying to instance usage in the
original Availability Zone and start applying to usage in the new
Availability Zone. If you modify the Network Platform of a Reserved
Instance, its capacity reservation stops applying to instance usage with
the original Network Platform and starts applying to usage with the new
Network Platform; however, its pricing benefit continues to apply to
both EC2-Classic and EC2-VPC instance usage that matches the rest of the
Reserved Instance parameters.
