### PR TITLE
Fix reduce() error, rename environment variables

### DIFF
--- a/ec2-check-reserved-instances.py
+++ b/ec2-check-reserved-instances.py
@@ -81,7 +81,7 @@ else:
 	for unreserved_instance in unreserved_instances:
 		print "Instance not reserved:\t(%s)\t%s\t%s" % ( unreserved_instances[ unreserved_instance ], unreserved_instance[0], unreserved_instance[1] )
 
-qty_running_instances = reduce( lambda x, y: x+y, running_instances.values() )
-qty_reserved_instances = reduce( lambda x, y: x+y, reserved_instances.values() )
+qty_running_instances = reduce( lambda x, y: x+y, running_instances.values() or [0] )
+qty_reserved_instances = reduce( lambda x, y: x+y, reserved_instances.values() or [0] )
 
 print "\n(%s) running on-demand instances\n(%s) reservations" % ( qty_running_instances, qty_reserved_instances )

--- a/ec2-check-reserved-instances.py
+++ b/ec2-check-reserved-instances.py
@@ -13,8 +13,8 @@ try:
 	AWS_ACCESS_KEY_ID
 except NameError:
 	try:
-		AWS_ACCESS_KEY_ID=os.environ['AWSAccessKeyId']
-		AWS_SECRET_ACCESS_KEY=os.environ['AWSSecretKey']
+		AWS_ACCESS_KEY_ID=os.environ['AWS_ACCESS_KEY_ID']
+		AWS_SECRET_ACCESS_KEY=os.environ['AWS_SECRET_ACCESS_KEY']
 	except KeyError:
 		print "Please set env variable"
 		sys.exit(1)


### PR DESCRIPTION
There are two commits here. One for renaming the aws credential environment variables to something more common (at least in my experience) and another for when no instances are found so the script doesn't end with an uncaught exception.
